### PR TITLE
Switch to use clj-http instead of clj-httpc

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,5 +2,5 @@
   :description "Pusher (http://www.pusherapp.com) Client for Clojure"
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.clojure/data.json "0.1.2"]
-                 [clj-httpc "1.7.1-2"]]
+                 [clj-http "0.3.5"]]
   :dev-dependencies [[swank-clojure "1.4.0-SNAPSHOT"]])

--- a/src/pusher.clj
+++ b/src/pusher.clj
@@ -1,6 +1,6 @@
 (ns pusher
  (:require
-   [clj-httpc.client :as http]
+   [clj-http.client :as http]
    [pusher.auth :as auth])
  (:use
    [clojure.data.json :only [json-str]]))

--- a/src/pusher/auth.clj
+++ b/src/pusher/auth.clj
@@ -2,7 +2,6 @@
  (:require
    [uk.co.holygoat.util.md5 :as md5])
  (:use
-   [clojure.contrib.java-utils :only [as-str]]
    [clojure.string :only [join]])
  (:import
    (javax.crypto Mac)
@@ -43,8 +42,8 @@
 
 (defn- parameter-string [params]
   (join "&"
-        (map (fn [[key val]] (str (as-str key) "=" (as-str val)))
-             (sort-by #(as-str (key %)) java.lang.String/CASE_INSENSITIVE_ORDER params))))
+        (map (fn [[key val]] (str (name key) "=" (str val)))
+             (sort-by #(name (key %)) java.lang.String/CASE_INSENSITIVE_ORDER params))))
 
 (defn- signature-string [request]
   (join "\n" [(request :method) (request :path) (parameter-string (request :query))]))


### PR DESCRIPTION
I ran into some weird (with my limited java experience anyway) clashes with dependencies while using clj-pusher in a [noir-cljs](https://github.com/ibdknox/noir-cljs) project.

```
Exception in thread "main" java.lang.RuntimeException: java.lang.ClassNotFoundException: com.google.gdata.util.ContentType
at clojure.lang.Util.runtimeException(Util.java:165)
at clojure.lang.Compiler.eval(Compiler.java:6476)
at clojure.lang.Compiler.eval(Compiler.java:6455)
...
```

Seems to be caused by `com.google.gdata/gdata-core-1.0` which is pulled in by [clj-httpc](https://github.com/retiman/clj-httpc).  As the clj-httpc seems abandoned anyway, and they instruct to use [clj-http](https://github.com/dakrone/clj-http), I updated clj-pusher to depend on that instead. Also removed the dependency from `clojure.contrib.java_utils`, which makes it nicer to use with 1.3.0 projects (contrib was also pulled in by clj-httpc)
