### PR TITLE
Add a cluster to the pusher url

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Library can be installed as a dependency from [Clojars](http://clojars.org/clj-p
 
     (with-pusher-auth ["my-pusher-app-id" "my-pusher-key" "my-pusher-secret"]
       (with-pusher-channel "test_channel"
-        (trigger "my_event" {:data "helloworld"}))))
+        (with-pusher-cluster "ap3"
+          (trigger "my_event" {:data "helloworld"}))))
 
 or with credentials set permanently
 
@@ -30,7 +31,9 @@ or with credentials set permanently
       (constantly "my-pusher-secret"))
     (alter-var-root (var *pusher-channel*)
       (constantly "test_channel"))
-
+    (alter-var-root (var *pusher-cluster*)
+      (constantly "ap3"))
+      
     (trigger "my_event" {:data "helloworld"})
 
 ##Copyright

--- a/src/pusher.clj
+++ b/src/pusher.clj
@@ -9,8 +9,9 @@
 (def ^{:dynamic true} *pusher-key* nil)
 (def ^{:dynamic true} *pusher-secret* nil)
 (def ^{:dynamic true} *pusher-channel* nil)
+(def ^{:dynamic true} *pusher-cluster* "ap2")
 
-(def pusher-api-host "https://api-ap2.pusher.com")
+(def pusher-api-host "https://api-%s.pusher.com")
 
 (defmacro with-pusher-auth [[app-id key secret] & body]
   `(binding [*pusher-app-id* ~app-id *pusher-key* ~key *pusher-secret* ~secret]
@@ -20,11 +21,15 @@
   `(binding [*pusher-channel* ~channel]
      ~@body))
 
+(defmacro with-pusher-cluster [cluster & body]
+  `(binding [*pusher-cluster* ~cluster]
+     ~@body))
+
 (defn- channel-events-path []
   (str "/apps/" *pusher-app-id* "/channels/" *pusher-channel* "/events"))
 
 (defn- uri [path]
-  (str pusher-api-host path))
+  (str (format pusher-api-host *pusher-cluster*) path))
 
 (defstruct request :method :path :query :body)
 

--- a/src/pusher.clj
+++ b/src/pusher.clj
@@ -10,7 +10,7 @@
 (def ^{:dynamic true} *pusher-secret* nil)
 (def ^{:dynamic true} *pusher-channel* nil)
 
-(def pusher-api-host "http://api.pusherapp.com")
+(def pusher-api-host "https://api-ap2.pusher.com")
 
 (defmacro with-pusher-auth [[app-id key secret] & body]
   `(binding [*pusher-app-id* ~app-id *pusher-key* ~key *pusher-secret* ~secret]


### PR DESCRIPTION
Pusher now uses the `https://api-ap2.pusher.com` instead of the earlier `https://api.pusher.com`

`ap2` is the cluster 

Hence made the base url as `https://api-%s.pusher.com` and override this using the new `with-cluster` macro